### PR TITLE
switch markdownlint container to markdownlint-cli2

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,9 @@
+# Reference: https://github.com/DavidAnson/markdownlint-cli2#markdownlint-cli2yaml
+
+config:
+  ul-indent:
+    # Kramdown wanted us to have 3 earlier, tho this CLI recommends 2 or 4
+    indent: 3
+
+# Don't autofix anything, we're linting here
+fix: false

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,5 +1,7 @@
 # Metal3.io Adopters
 
+<!-- markdownlint-disable MD013 -->
+
 | Type | Name | Since | Website | Use-Case |
 |:-----|:-----|:------|:--------|:---------|
 | Integration | Ericsson | 2019 | [link](https://www.ericsson.com/en/portfolio/digital-services/cloud-infrastructure/cloud-container-distribution) | As a Kubernetes distributor we are building Cloud Container Distribution (CCD) and integrating Metal3 project for baremetal deployments and for baremetal cluster LCM tasks. |
@@ -10,3 +12,5 @@
 | Integration | IKEA IT AB | 2020 | | IKEA IT AB uses Metal3 to handle BareMetal provisioning and lifecycle management in its CAPI-Based bare metal cloud infrastructure. |
 | Integration | PITS Global Data Recovery Services | 2023 | [link](https://pitsdatarecovery.net/)| The Metal3 is used to manage highly-loaded internal infrastructure prividing reliable and flexible k8s solutions. |
 | Integration | SUSE | 2023 | [link](https://suse-edge.github.io)| Metal3 is used for automated bare metal deployment as part of the SUSE Edge solution. |
+
+<!-- markdownlint-enable MD013 -->

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,31 +1,20 @@
 #!/bin/sh
-
-# TODO:
-# Fix markdownlint complaints
-#
-# - MD013: enforcing this breaks table-formatting
-#
-# Further documentation is available for these failures:
-#  - MD013: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md013---line-length
+# markdownlint-cli2 has config file(s) named .markdownlint-cli2.yaml in the repo
 
 set -eux
 
 IS_CONTAINER="${IS_CONTAINER:-false}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
+# all md files, but ignore .github
 if [ "${IS_CONTAINER}" != "false" ]; then
-    TOP_DIR="${1:-.}"
-    find "${TOP_DIR}" \
-      -name '*.md' -exec \
-      mdl --style all --warnings \
-      --rules "~MD013" \
-      {} \+
+    markdownlint-cli2 "**/*.md" "#.github"
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/pipelinecomponents/markdownlint:0.13.0@sha256:9c0cdfb64fd3f1d3bdc5181629b39c2e43b6a52fc9fdc146611e1860845bbae0 \
+        docker.io/pipelinecomponents/markdownlint-cli2:0.9.0@sha256:71370df6c967bae548b0bfd0ae313ddf44bfad87da76f88180eff55c6264098c \
         /workdir/hack/markdownlint.sh "$@"
 fi


### PR DESCRIPTION
Switch markdownlint container to markdownline-cli2. This CLI version supports the enable/disable rules in markdown files and allows us to ignore issues locally, not just globally.

TODO: 
- [ ] project-infra PR https://github.com/metal3-io/project-infra/pull/619 needs to merge before new markdownlint here can pass
