### PR TITLE
add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,18 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
- - dtantsur
- - elfosardo
- - kashifest
- - lentzi90
- - Rozzii
- - tuminoid
+- community-maintainers
 
 reviewers:
- - honza
- - mboukhalfa
- - smoshiur1237
- - zaneb
+- community-maintainers
+- community-reviewers
 
 emeritus_reviewers:
 

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  community-maintainers:
+  - dtantsur
+  - elfosardo
+  - kashifest
+  - lentzi90
+  - Rozzii
+  - tuminoid
+
+  community-reviewers:
+  - honza
+  - mboukhalfa
+  - smoshiur1237
+  - zaneb


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.