### PR TITLE
add openssf best practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Metal3 community
 
 [![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/metal3-io/badge)](https://clomonitor.io/projects/cncf/metal3-io)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9160/badge)](https://www.bestpractices.dev/projects/9160)
 
 Welcome to Metal3 community! This repository contains governance materials
 related to the Metal3 community.


### PR DESCRIPTION
We have achieved passing badge on OpenSSF Best Practices. Adding badge to key repositories to display this achievement. It is also checked by the CLOmonitor and is required to move up to incubated project in CNCF.