### PR TITLE
remove ironic-client from all-owner.sh

### DIFF
--- a/maintainers/all-owners.sh
+++ b/maintainers/all-owners.sh
@@ -11,7 +11,6 @@ declare -a REPOS=(
     cluster-api-provider-metal3
     community
     ip-address-manager
-    ironic-client
     ironic-hardware-inventory-recorder-image
     ironic-image
     ironic-ipa-downloader


### PR DESCRIPTION
Ironic client will be archived as content is merged into ironic-image.

Ref: https://github.com/metal3-io/ironic-client/issues/30