### PR TITLE
remove obsolete CII Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Metal3 community
 
 [![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/metal3-io/badge)](https://clomonitor.io/projects/cncf/metal3-io)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9160/badge)](https://www.bestpractices.dev/projects/9160)
 
 Welcome to Metal3 community! This repository contains governance materials
 related to the Metal3 community.


### PR DESCRIPTION
We cannot use CII Best Practices badge here. It is per repository, not per project. Hence the badge does not make sense here. This common project will be removed soon and that breaks the old badge as well.