### PR TITLE
Fix all-owners.sh when it adds new maintainers

### DIFF
--- a/maintainers/all-owners.sh
+++ b/maintainers/all-owners.sh
@@ -112,7 +112,12 @@ for owner in "${OWNER_TYPES[@]}"; do
         # match the GitHub handle against the CNCF maintainer file
         # remove the double ',' and the windows carrige return from the lines
         individual="$(grep "${maintainer}" "project-maintainers.csv" | sed -e 's/,,//g' | sed -e 's/\r//g')"
-        mail=$(find_mail "${individual%%,*}")
-        echo "- ${individual}${mail}"
+        if [[ -z "${individual}" ]]; then
+            # If not found in CNCF CSV, print the maintainer as-is with placeholders
+            echo "- ${maintainer},----UNKNOWN_AFFILIATION-----"
+        else
+            mail=$(find_mail "${individual%%,*}")
+            echo "- ${individual}${mail}"
+        fi
     done
 done


### PR DESCRIPTION
Current script when it finds a new maintainer in one of the repos, adds an empty line since the new maintainer is missing in CNCF's project-maintainers.csv as this is a new maintainer. Instead the fix now prints the github handle and UKNOWN AFFILIATION next to it in the output of the script so that the list can be fixed manually by adding the affiliation and email of the new maintainer.

Example:
Output before the fix:

```
- Lennart Jern,Ericsson Software Technology,lentzi90,lennart.jern@est.tech 
- 
- Adam Rozman,Ericsson Software Technology,Rozzii,adam.rozman@est.tech
```

Output after the fix:
```
- Lennart Jern,Ericsson Software Technology,lentzi90,lennart.jern@est.tech
- peppi-lotta,----UNKNOWN_AFFILIATION-----
- Adam Rozman,Ericsson Software Technology,Rozzii,adam.rozman@est.tech
```