### PR TITLE
lint: allow long lines in tables and code fences

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,6 +4,9 @@ config:
   ul-indent:
     # Kramdown wanted us to have 3 earlier, tho this CLI recommends 2 or 4
     indent: 3
+  line-length:
+    tables: false
+    code_blocks: false
 
 # Don't autofix anything, we're linting here
 fix: false

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,7 +1,5 @@
 # Metal3.io Adopters
 
-<!-- markdownlint-disable MD013 -->
-
 | Type | Name | Since | Website | Use-Case |
 |:-----|:-----|:------|:--------|:---------|
 | Integration | Ericsson | 2019 | [link](https://www.ericsson.com/en/portfolio/cloud-software-and-services/cloud-core/cloud-infrastructure/cloud-native-infrastructure/cloud-container-distribution) | As a Kubernetes distributor we are building Cloud Container Distribution (CCD) and integrating Metal3 project for baremetal deployments and for baremetal cluster LCM tasks. |
@@ -14,5 +12,3 @@
 | Integration | PITS Global Data Recovery Services | 2023 | [link](https://pitsdatarecovery.net/)| The Metal3 is used to manage highly-loaded internal infrastructure prividing reliable and flexible k8s solutions. |
 | Integration | SUSE | 2023 | [link](https://suse-edge.github.io)| Metal3 is used for automated bare metal deployment as part of the SUSE Edge solution. |
 | Integration | Sylva | 2022 | [link](https://sylvaproject.org)| Sylva uses Cluster API to manage clusters lifecycle, with CAPM3 and Metal3 for baremetal. |
-
-<!-- markdownlint-enable MD013 -->


### PR DESCRIPTION
Allow lines longer than 80 chars, if they're in tables or code fences. In those, long lines cannot often be avoided, and ignoring them one by one is painful and not pretty.

The same change is applied to all repos with markdownlint, but only on main. Documentation is 99% of the time maintained only in main, so it doesn't matter in release branches.