### PR TITLE
add zizmor scanner

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+---
+# Static analysis for GitHub Actions workflows
+# https://docs.zizmor.sh/
+name: zizmor
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    # Upload SARIF to Security tab on push to main
+    - name: Run zizmor (SARIF)
+      if: github.event_name == 'push'
+      uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
+    # Block PRs with findings
+    - name: Run zizmor (PR check)
+      if: github.event_name == 'pull_request'
+      uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
+      with:
+        advanced-security: false


### PR DESCRIPTION
Zizmor scans workflow files to keep them hardened. It runs on push to produce a report in security tab, and it runs on PRs and blocks them if they is any errors.