### PR TITLE
Correcting misnamed user-guide key in Security Insights file

### DIFF
--- a/.github/security-insights.yml
+++ b/.github/security-insights.yml
@@ -26,7 +26,7 @@ project:
   documentation:
     code-of-conduct: https://github.com/cncf/foundation/blob/main/code-of-conduct.md
     support-policy: https://book.metal3.io/version_support.html
-    user-guide: https://book.metal3.io
+    detailed-guide: https://book.metal3.io
   repositories:
   - name: baremetal-operator
     url: https://github.com/metal3-io/baremetal-operator


### PR DESCRIPTION
According to the security insights spec 2.2.0 the correct key is 'detailed-guide'.

This misnamed field results in OpenSSF OSPS baseline scanner throwing an error and failing the check:

> ❯ ./pvtr run --loglevel DEBUG --binaries-path . -c config.yml
2026-06-12T12:12:13.890+0200 [DEBUG] starting plugin: path=local/github-repo args=["local/github-repo", "--config=config.yml", "--loglevel=DEBUG", "--service=evaluation-evaluation"]
2026-06-12T12:12:13.892+0200 [DEBUG] plugin started: path=local/github-repo pid=91788
2026-06-12T12:12:13.892+0200 [DEBUG] waiting for RPC address: plugin=local/github-repo
2026-06-12T12:12:14.070+0200 [DEBUG] using plugin: version=1
2026-06-12T12:12:14.070+0200 [DEBUG] github-repo: plugin address: address=/var/folders/sc/kzhlkxn5207_hyl1n5s2n8dw0000gp/T/plugin1777112 network=unix timestamp="2026-06-12T12:12:14.070+0200"
2026-06-12T12:12:16.436+0200 [ERROR] failed to read security insights file: error unmarshalling SI: [29:5] unknown field "user-guide"
  26 |   documentation:
  27 |     code-of-conduct: https://github.com/cncf/foundation/blob/main/code-of-conduct.md
  28 |     support-policy: https://book.metal3.io/version_support.html
> 29 |     user-guide: https://book.metal3.io
           ^
  30 |   repositories:
  31 |   - name: baremetal-operator
  32 |     url: https://github.com/metal3-io/baremetal-operator
  33 |
2026-06-12T12:12:17.099+0200 [INFO]  OSPS-AC-01.01: This control is enforced by GitHub for all projects
2026-06-12T12:12:17.099+0200 [INFO]  OSPS-AC-02.01: This control is enforced by GitHub for all projects
2026-06-12T12:12:17.100+0200 [ERROR] OSPS-AC-03.01: Default branch is not protected
2026-06-12T12:12:18.113+0200 [ERROR] OSPS-BR-01.01: Error parsing workflow: [:33:26: could not parse as YAML: mapping values are not allowed in this context [syntax-check]] (.github/workflows/zizmor.yml)
2026-06-12T12:12:18.113+0200 [WARN]  OSPS-BR-03.01: All links use HTTPS
2026-06-12T12:12:18.113+0200 [INFO]  OSPS-BR-03.02: No official distribution points found in Security Insights data
2026-06-12T12:12:18.113+0200 [INFO]  OSPS-BR-07.01: Secret scanning is enabled and prevents pushing secrets
2026-06-12T12:12:18.113+0200 [ERROR] OSPS-DO-01.01: User guide was NOT specified in Security Insights data
2026-06-12T12:12:18.113+0200 [ERROR] OSPS-DO-02.01: Both issues and discussions are disabled for the repository
2026-06-12T12:12:18.113+0200 [ERROR] OSPS-GV-02.01: Both issues and discussions are disabled for the repository
2026-06-12T12:12:18.113+0200 [WARN]  OSPS-GV-03.01: Contributing guide was found via GitHub API (Recommendation: Add code of conduct location to Security Insights data)
2026-06-12T12:12:18.290+0200 [INFO]  OSPS-LE-02.01: All license found are OSI or FSF approved
2026-06-12T12:12:18.290+0200 [INFO]  OSPS-LE-02.02: All license found are OSI or FSF approved
2026-06-12T12:12:18.290+0200 [INFO]  OSPS-LE-03.01: License was found in a well known location via the GitHub API
2026-06-12T12:12:18.291+0200 [INFO]  OSPS-LE-03.02: No releases found
2026-06-12T12:12:18.291+0200 [INFO]  OSPS-QA-01.01: Repository is public
2026-06-12T12:12:18.291+0200 [INFO]  OSPS-QA-01.02: This control is enforced by GitHub for all projects
2026-06-12T12:12:18.291+0200 [WARN]  OSPS-QA-02.01: No dependency manifests found in the GitHub dependency graph API. Review project to ensure dependencies are managed.
2026-06-12T12:12:18.291+0200 [ERROR] OSPS-QA-04.01: Insights does not contain a list of repositories
2026-06-12T12:12:19.544+0200 [INFO]  OSPS-QA-05.01: No common binary file extensions were found in the repository
2026-06-12T12:12:19.544+0200 [INFO]  OSPS-QA-05.02: No unreviewable binary artifacts were found in the repository
2026-06-12T12:12:19.544+0200 [ERROR] OSPS-VM-02.01: Security contacts were not specified in Security Insights data
2026-06-12T12:12:19.544+0200 [ERROR] > evaluation-evaluation_osps-baseline-2026-02: 7 Passed, 3 Warnings, 7 Failed, 40 Possible
2026-06-12T12:12:19.557+0200 [WARN]  Unexpected exit from evaluation-evaluation with no error or success
2026-06-12T12:12:19.562+0200 [INFO]  plugin process exited: plugin=local/github-repo id=91788
2026-06-12T12:12:19.562+0200 [DEBUG] plugin exited