### PR TITLE
Fixing indentation error in zizmor workflow specification

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -30,7 +30,7 @@ jobs:
       uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
       with:
         config: .zizmor.yml
-         advanced-security: true
+        advanced-security: true
     # Block PRs with findings
     - name: Run zizmor (PR check)
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
I came across this typo because the OpenSSF OSPS baseline scanner choked on it:

> ❯ ./pvtr run --loglevel DEBUG --binaries-path . -c config.yml
2026-06-12T12:18:27.623+0200 [DEBUG] starting plugin: path=local/github-repo args=["local/github-repo", "--config=config.yml", "--loglevel=DEBUG", "--service=evaluation-evaluation"]
2026-06-12T12:18:27.625+0200 [DEBUG] plugin started: path=local/github-repo pid=92327
2026-06-12T12:18:27.625+0200 [DEBUG] waiting for RPC address: plugin=local/github-repo
2026-06-12T12:18:27.800+0200 [DEBUG] using plugin: version=1
2026-06-12T12:18:27.801+0200 [DEBUG] github-repo: plugin address: address=/var/folders/sc/kzhlkxn5207_hyl1n5s2n8dw0000gp/T/plugin2326678127 network=unix timestamp="2026-06-12T12:18:27.800+0200"
2026-06-12T12:18:30.514+0200 [INFO]  OSPS-AC-01.01: This control is enforced by GitHub for all projects
2026-06-12T12:18:30.514+0200 [INFO]  OSPS-AC-02.01: This control is enforced by GitHub for all projects
2026-06-12T12:18:30.514+0200 [ERROR] OSPS-AC-03.01: Default branch is not protected
2026-06-12T12:18:31.302+0200 [ERROR] OSPS-BR-01.01: Error parsing workflow: [:33:26: could not parse as YAML: mapping values are not allowed in this context [syntax-check]] (.github/workflows/zizmor.yml)